### PR TITLE
more bundler stuff

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+BUNDLE_PATH: .vendor/bundle
+BUNDLE_DISABLE_SHARED_GEMS: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# ignore OS stuff
 **/.DS_Store
+
+# ignore dev deps
 **/node_modules/
+.vendor
+
+# ignore generated files
 **/_site
+**/.sass-cache

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,8 @@
 source 'https://rubygems.org'
+
+# don't install newer than 1.9.18
+# @see https://github.com/ffi/ffi/issues/608
+gem 'ffi', '1.9.18'
+
+# We're publishing to GitHub Pages
 gem 'github-pages', group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ffi (= 1.9.18)
   github-pages
 
 BUNDLED WITH
-   1.15.0
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ rvm use
 bundle install
 ```
 
+If you run into issues installing `nokogiri` try following the package installation/upgrade commands for your system in this [nokogiri GitHub issue](https://github.com/sparklemotion/nokogiri/issues/1099).
+
 ### Install the front end dependencies
 
 ```

--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ git clone git@github.com:UN-OCHA/styleguide.git
 ### Install the required gems
 
 ```
-cd styleguide
-bundle
+rvm use
+bundle install
 ```
 
 ### Install the front end dependencies
 
 ```
+nvm use
 npm install
 ```
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,0 @@
-.sass-cache

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "get-rw-js": "copyfiles -f /srv/rwint/data/code/site/site/profiles/reliefweb/themes/kobe/js/responsive.js /srv/rwint/data/code/site/site/profiles/reliefweb/modules/features/reliefweb_rivers/js/responsive-river.js /srv/rwint/data/code/site/site/profiles/reliefweb/modules/features/reliefweb_rivers/js/responsive-search.js /srv/rwint/data/code/site/site/sites/all/libraries/SimpleAutocomplete.js/simpleautocomplete.js /srv/rwint/data/code/site/site/sites/all/libraries/SimpleDatePicker.js/simpledatepicker.js docs/assets/rw/",
     "get-rw-icons": "copyfiles -f /srv/rwint/data/code/site/site/profiles/reliefweb/themes/kobe/images/icon-sprite.svg /srv/rwint/data/code/site/site/profiles/reliefweb/themes/kobe/images/icon-sprite.png docs/assets/rw/images/",
     "update-rw-assets": "npm run get-rw-css && npm run get-rw-js && npm run get-rw-icons",
-    "jekyll": "jekyll serve --source='docs' --baseurl=''"
+    "jekyll": "bundle exec jekyll serve --source='docs' --baseurl=''"
   },
   "devDependencies": {
     "autoprefixer": "^8.0.0",


### PR DESCRIPTION
We had some installation troubles when using the default `ffi 1.9.21` so let's try it with a slightly older version.