### PR TITLE
Create 404 page with link to file an issue

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,42 @@
+---
+layout: default
+title: Page Not Found
+permalink: /404.html
+---
+<div class="cd-container sg-container">
+	<div class="sg-page-header">
+		<h1>404: Page Not Found</h1>
+		<p><strong>The URL you loaded doesn't exist.</strong> We apologize for the inconvenience. If you believe this is a problem with the styleguide, <a id="gh-issue-404" target="_blank" rel="noopener" href="https://github.com/UN-OCHA/styleguide/issues/new">please file an issue on GitHub</a></p>
+		<p>The guide is a living document created to meet the needs of OCHA's developers and designers. If you have any feedback, questions or comment please contact <a href="mailto:digitalservices@humanitarianresponse.info">digitalservices@humanitarianresponse.info</a>.</p>
+		<script>
+			var href = document.querySelector('#gh-issue-404').getAttribute('href');
+			document.querySelector('#gh-issue-404').setAttribute('href', href + '?title=404+on+styleguide&body=' + encodeURI(window.location) + '+results+in+404+on+official+styleguide');
+		</script>
+	</div>
+
+	<div class="sg-list">
+		<div class="sg-list__item">
+			<h2 class="sg-list__sub-heading">Common Design</h2>
+			<p>A unified design system for OCHA platforms.</p>
+			<p><a href="common-design">Common Design</a></p>
+		</div>
+
+		<div class="sg-list__item">
+			<h2 class="sg-list__sub-heading">OCHA Basic Drupal Theme</h2>
+			<p>OCHA Basic is a minimal starter theme for Drupal incorporating the Common Design header and footer.</p>
+			<p><a href="ocha">OCHA Basic theme</a></p>
+		</div>
+
+		<div class="sg-list__item">
+			<h2 class="sg-list__sub-heading">Individual website component libraries</h2>
+			<p><a href="hid">Humanitarian ID component library &amp; guidelines</a></p>
+			<p><a href="reliefweb">ReliefWeb component library &amp; guidelines</a></p>
+		</div>
+
+		<div class="sg-list__item">
+			<h2 class="sg-list__sub-heading">Shared libraries</h2>
+			<p><a href="icons">Icon library</a></p>
+		</div>
+	</div>
+
+</div>


### PR DESCRIPTION
I have run into some 404s on the styleguide while clicking around. This PR creates a [GitHub Pages 404 page](https://help.github.com/articles/creating-a-custom-404-page-for-your-github-pages-site/) with a link to file an issue against this repo. When clicked, the link will automatically direct a user to something like this, provided they're logged into GitHub already:

<img width="790" alt="github-file-new-issue" src="https://user-images.githubusercontent.com/254753/42641693-64923bd6-85f5-11e8-824e-820500821f41.png">

The URL will be auto-populated from the real site as well. The way GitHub Pages works, it will be the actual URL that's 404ing, not the 404 page as in my example.

I left the rest of the frontpage content on the 404 to give people something to click on. Maybe that's not the right thing to do and we should just send them to the front to start from the top. Thoughts?