### PR TITLE
CD-34: Minor cleanup of markup in <head>

### DIFF
--- a/.bin/deploy.sh
+++ b/.bin/deploy.sh
@@ -9,7 +9,7 @@ export NODE_ENV='production'
 
 # build assets
 gulp deploy
-git add css js
+git add assets common-design ocha styleguide
 
 # instruct developer to review/commit/push
 echo ""

--- a/_includes/head-cd.html
+++ b/_includes/head-cd.html
@@ -2,7 +2,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{%if page.page-title %} {{page.page-title}} | {% endif %}{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="viewport" content="width=device-width initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="{{ site.description }}">
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">

--- a/_includes/head-cd.html
+++ b/_includes/head-cd.html
@@ -1,27 +1,25 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{%if page.page-title %} {{page.page-title}} | {% endif %}{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+    <title>{% if page.page-title %} {{ page.page-title }} | {% endif %}{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="{{ site.description }}">
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-    <script src="{{ "/assets/js/modernizr.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ '/assets/js/modernizr.js' | prepend: site.baseurl }}"></script>
 
-    <link rel="stylesheet" href="{{ "/common-design/css/styles.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ '/common-design/css/styles.css' | prepend: site.baseurl }}">
 
-
-    <link rel="apple-touch-icon" sizes="180x180" href="{{ "/apple-touch-icon.png" | prepend: site.baseurl }}">
-    <link rel="icon" type="image/png" href="{{ "/favicon-32x32.png" | prepend: site.baseurl }}" sizes="32x32">
-    <link rel="icon" type="image/png" href="{{ "/favicon-16x16.png" | prepend: site.baseurl }}" sizes="16x16">
-    <link rel="manifest" href="{{ "/manifest.json" | prepend: site.baseurl }}">
-    <link rel="mask-icon" href="{{ "/safari-pinned-tab.svg" | prepend: site.baseurl }}" color="#5bbad5">
-    <link rel="shortcut icon" type="image/x-icon" href="{{ "/favicon.ico" | prepend: site.baseurl }}">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ '/apple-touch-icon.png' | prepend: site.baseurl }}">
+    <link rel="icon" type="image/png" href="{{ '/favicon-32x32.png' | prepend: site.baseurl }}" sizes="32x32">
+    <link rel="icon" type="image/png" href="{{ '/favicon-16x16.png' | prepend: site.baseurl }}" sizes="16x16">
+    <link rel="manifest" href="{{ '/manifest.json' | prepend: site.baseurl }}">
+    <link rel="mask-icon" href="{{ '/safari-pinned-tab.svg' | prepend: site.baseurl }}" color="#5bbad5">
+    <link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | prepend: site.baseurl }}">
 
     <script
       src="https://code.jquery.com/jquery-1.12.4.min.js"
       integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
       crossorigin="anonymous"></script>
     <script src="https://cdn.rawgit.com/UN-OCHA/ocha_basic/master/js/bootstrap-dropdown.js"></script>
-
 </head>

--- a/_includes/head-cd.html
+++ b/_includes/head-cd.html
@@ -1,8 +1,8 @@
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{%if page.page-title %} {{page.page-title}} | {% endif %}{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+    <meta name="viewport" content="width=device-width initial-scale=1" />
     <meta name="description" content="{{ site.description }}">
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,14 +13,7 @@
     {% if page.include_hid %}
     <link rel="stylesheet" href="https://app2.dev.humanitarian.id/css/app.min.css">
     {% endif %}
-    {% if page.include_rw %}
-    <!--[if IE 8]>
-    <link rel="stylesheet" href="{{ '/assets/rw/styles-ie8.css' | prepend: site.baseurl }}">
-    <![endif]-->
-    <!--[if !IE]><!-->
-    <link rel="stylesheet" href="{{ '/assets/rw/styles.css' | prepend: site.baseurl }}">
-    <!--<![endif]-->
-    {% endif %}
+
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <script src="{{ '/assets/js/modernizr.js' | prepend: site.baseurl }}"></script>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600" rel="stylesheet">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,8 +1,8 @@
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{%if page.page-title %} {{page.page-title}} | {% endif %}{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+    <meta name="viewport" content="width=device-width initial-scale=1" />
     <meta name="description" content="{{ site.description }}">
     <link rel="stylesheet" href="{{site.baseurl}}/styleguide/css/styleguide.css" type="text/css">
     <link rel="stylesheet" href="{{site.baseurl}}/styleguide/css/chosen/chosen.min.css" type="text/css">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,18 +15,18 @@
     {% endif %}
     {% if page.include_rw %}
     <!--[if IE 8]>
-    <link rel="stylesheet" href="{{ "/assets/rw/styles-ie8.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ '/assets/rw/styles-ie8.css' | prepend: site.baseurl }}">
     <![endif]-->
     <!--[if !IE]><!-->
-    <link rel="stylesheet" href="{{ "/assets/rw/styles.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ '/assets/rw/styles.css' | prepend: site.baseurl }}">
     <!--<![endif]-->
     {% endif %}
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-    <script src="{{ "/assets/js/modernizr.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ '/assets/js/modernizr.js' | prepend: site.baseurl }}"></script>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600" rel="stylesheet">
 
     {% if page.hide_header_footer != true %}
-    <link rel="stylesheet" href="{{ "/common-design/css/styles.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ '/common-design/css/styles.css' | prepend: site.baseurl }}">
     {% endif %}
 
     {% if page.custom_css %}
@@ -35,12 +35,12 @@
       {% endfor %}
     {% endif %}
 
-    <link rel="apple-touch-icon" sizes="180x180" href="{{ "/apple-touch-icon.png" | prepend: site.baseurl }}">
-    <link rel="icon" type="image/png" href="{{ "/favicon-32x32.png" | prepend: site.baseurl }}" sizes="32x32">
-    <link rel="icon" type="image/png" href="{{ "/favicon-16x16.png" | prepend: site.baseurl }}" sizes="16x16">
-    <link rel="manifest" href="{{ "/manifest.json" | prepend: site.baseurl }}">
-    <link rel="mask-icon" href="{{ "/safari-pinned-tab.svg" | prepend: site.baseurl }}" color="#5bbad5">
-    <link rel="shortcut icon" type="image/x-icon" href="{{ "/favicon.ico" | prepend: site.baseurl }}">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ '/apple-touch-icon.png' | prepend: site.baseurl }}">
+    <link rel="icon" type="image/png" href="{{ '/favicon-32x32.png' | prepend: site.baseurl }}" sizes="32x32">
+    <link rel="icon" type="image/png" href="{{ '/favicon-16x16.png' | prepend: site.baseurl }}" sizes="16x16">
+    <link rel="manifest" href="{{ '/manifest.json' | prepend: site.baseurl }}">
+    <link rel="mask-icon" href="{{ '/safari-pinned-tab.svg' | prepend: site.baseurl }}" color="#5bbad5">
+    <link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | prepend: site.baseurl }}">
 
     <style>html.hidden {display: block}</style>
     <script
@@ -51,10 +51,10 @@
     <script src="https://cdn.rawgit.com/UN-OCHA/ocha_basic/master/js/bootstrap-dropdown.js"></script>
     {% endif %}
     {% if page.include_rw %}
-    <script src="{{ "/assets/rw/simpleautocomplete.js" | prepend: site.baseurl }}"></script>
-    <script src="{{ "/assets/rw/simpledatepicker.js" | prepend: site.baseurl }}"></script>
-    <script src="{{ "/assets/rw/responsive.js" | prepend: site.baseurl }}"></script>
-    <script src="{{ "/assets/rw/responsive-river.js" | prepend: site.baseurl }}"></script>
-    <script src="{{ "/assets/rw/responsive-search.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ '/assets/rw/simpleautocomplete.js' | prepend: site.baseurl }}"></script>
+    <script src="{{ '/assets/rw/simpledatepicker.js' | prepend: site.baseurl }}"></script>
+    <script src="{{ '/assets/rw/responsive.js' | prepend: site.baseurl }}"></script>
+    <script src="{{ '/assets/rw/responsive-river.js' | prepend: site.baseurl }}"></script>
+    <script src="{{ '/assets/rw/responsive-search.js' | prepend: site.baseurl }}"></script>
     {% endif %}
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{%if page.page-title %} {{page.page-title}} | {% endif %}{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="viewport" content="width=device-width initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="{{ site.description }}">
     <link rel="stylesheet" href="{{site.baseurl}}/styleguide/css/styleguide.css" type="text/css">
     <link rel="stylesheet" href="{{site.baseurl}}/styleguide/css/chosen/chosen.min.css" type="text/css">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
-<html class="styleguide">
+<html class="no-js">
   {% include head.html %}
 
-  <body>
-
+  <body class="styleguide">
     <div class="page-wrapper">
       {% if page.hide_header_footer != true %}
-       {% include header.html %}
+        {% include header.html %}
       {% endif %}
 
       {{ content }}
@@ -16,5 +15,4 @@
       {% include footer.html %}
     {% endif %}
   </body>
-
 </html>

--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -698,9 +698,6 @@ ul.cd-nav__grandchild-nav {
 .cd-sites-dropdown__logo--ocha {
   background-position: 0 -144px; }
 
-.cd-sites-dropdown__logo--rw {
-  background-position: 0 -162px; }
-
 @media (min-width: 768px) {
   .cd-sites-btn {
     display: -webkit-flex;
@@ -1052,5 +1049,3 @@ a.cd-footer-social__link {
     margin: 0 0 0 20px; }
     a.cd-footer-social__link:first-child {
       margin: 0; } }
-
-/*# sourceMappingURL=styles.css.map */

--- a/common-design/sass/cd-header/_cd-sites-menu.scss
+++ b/common-design/sass/cd-header/_cd-sites-menu.scss
@@ -148,10 +148,6 @@
   background-position: 0 -144px;
 }
 
-.cd-sites-dropdown__logo--rw {
-  background-position: 0 -162px;
-}
-
 @media (min-width: map-get($cd-breakpoints, tablet)) {
 
   .cd-sites-btn {

--- a/ocha/css/extras.css
+++ b/ocha/css/extras.css
@@ -171,5 +171,3 @@ label > input[type="radio"], label > input[type="checkbox"] {
   margin: 0;
   width: auto;
   height: auto; }
-
-/*# sourceMappingURL=extras.css.map */

--- a/styleguide/css/styleguide.css
+++ b/styleguide/css/styleguide.css
@@ -1328,12 +1328,6 @@ html.styleguide, html.styleguide body {
   vertical-align: text-top;
   line-height: 1; }
 
-.sg-icon-list--rw .icon {
-  vertical-align: bottom; }
-
-.sg-icon-list--rw .highlight {
-  margin-top: 0; }
-
 .sg-hidden {
   display: none; }
 
@@ -1489,5 +1483,3 @@ html.styleguide, html.styleguide body {
   margin: 20px;
   font-family: monospace;
   white-space: pre; }
-
-/*# sourceMappingURL=styleguide.css.map */

--- a/styleguide/sass/_styleguide.scss
+++ b/styleguide/sass/_styleguide.scss
@@ -151,16 +151,6 @@ html.styleguide, html.styleguide body {
   line-height: 1;
 }
 
-.sg-icon-list--rw {
-  .icon {
-    vertical-align: bottom;
-  }
-
-  .highlight {
-    margin-top: 0;
-  }
-}
-
 .sg-hidden {
   display: none;
 }


### PR DESCRIPTION
I noticed while doing some other stuff that there are a couple subtle oddities in the `head.html` include which have big effects. Filing an issue so I can come back and clean them up:

* ensure proper order to meta tags (`charset`, `X-UA-Compatible` have to come first, then `<title>`, then the rest)
* comma-separate the meta-viewport tag vals
* unify and standardize the URLs and Jekyll conventions in the head
* move the `styleguide` class from `<html>` to `<body>`
* remove straggler references to RW assets

## Testing

Just check the branch out locally and manually inspect HTML to ensure the above changes were made.