### PR TITLE
CD-30: style tweaks

### DIFF
--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -271,6 +271,7 @@ body {
   border-left: 1px solid #E6ECF1;
   font-size: 14px;
   font-weight: bold;
+  color: #4A4A4A;
   height: 60px;
   padding: 0 20px;
   text-transform: uppercase;
@@ -280,7 +281,8 @@ body {
     color: #EB5C6D; }
   .open .cd-site-header__nav-toggle {
     position: relative;
-    z-index: 101; }
+    z-index: 101;
+    color: #000; }
     .open .cd-site-header__nav-toggle:after {
       bottom: -3px;
       content: '';
@@ -294,6 +296,7 @@ body {
     .open .cd-site-header__nav-toggle:focus {
       background: #FFF; }
   .cd-site-header__nav-toggle:hover, .cd-site-header__nav-toggle:focus {
+    color: #000;
     background: #E6ECF1;
     outline: none; }
 
@@ -332,8 +335,10 @@ body {
 
 .cd-nav__item.open {
   background: #FFF; }
-  .cd-nav__item.open > button:hover, .cd-nav__item.open > button:focus {
-    background: #E6ECF1; }
+  .cd-nav__item.open > button {
+    color: #000; }
+    .cd-nav__item.open > button:hover, .cd-nav__item.open > button:focus {
+      background: #E6ECF1; }
 
 .cd-nav__item > a,
 .cd-nav__item > button {
@@ -351,13 +356,17 @@ ul.cd-nav__child-nav {
   background: #FFF; }
   ul.cd-nav__child-nav a,
   ul.cd-nav__child-nav button {
-    color: #000; }
+    color: #000;
+    font-weight: 600; }
     ul.cd-nav__child-nav a:hover,
     ul.cd-nav__child-nav button:hover {
       background: #E6ECF1; }
 
 ul.cd-nav__grandchild-nav {
   padding-bottom: 5px; }
+  ul.cd-nav__grandchild-nav a,
+  ul.cd-nav__grandchild-nav button {
+    font-weight: 200; }
 
 .cd-nav__grandchild-item a,
 .cd-nav__grandchild-item button {
@@ -475,7 +484,6 @@ ul.cd-nav__grandchild-nav {
   align-items: center;
   background: transparent;
   border: 0;
-  border-left: 1px solid #E6ECF1;
   color: #026CB6;
   display: -webkit-flex;
   display: flex;
@@ -1083,3 +1091,5 @@ a.cd-footer-social__link {
     margin: 0 0 0 20px; }
     a.cd-footer-social__link:first-child {
       margin: 0; } }
+
+/*# sourceMappingURL=styles.css.map */

--- a/common-design/sass/cd-header/_cd-nav.scss
+++ b/common-design/sass/cd-header/_cd-nav.scss
@@ -12,6 +12,7 @@
   border-left: 1px solid $cd-border-color;
   font-size: map-get($cd-font-sizes, medium);
   font-weight: bold;
+  color: $cd-default-text-color;
   height: $cd-site-header-height;
   padding: 0 20px;
   text-transform: uppercase;
@@ -25,6 +26,7 @@
   .open & {
     position: relative;
     z-index: 101;
+    color: $cd-dark-text-color;
 
     &:after {
       bottom: -3px;
@@ -45,6 +47,7 @@
 
   &:hover,
   &:focus {
+    color: $cd-dark-text-color;
     background: $cd-mid-bg-color;
     outline: none; // default browser outline is replaced by background colour change.
   }
@@ -96,6 +99,8 @@
     background: $cd-white-bg-color;
 
     & > button {
+      color: $cd-dark-text-color;
+
       &:hover,
       &:focus {
         background: $cd-mid-bg-color;
@@ -124,6 +129,7 @@ ul.cd-nav__child-nav {
   a,
   button {
     color: $cd-dark-text-color;
+    font-weight: 600;
 
     &:hover {
       background: $cd-mid-bg-color;
@@ -133,6 +139,10 @@ ul.cd-nav__child-nav {
 
 ul.cd-nav__grandchild-nav {
   padding-bottom: 5px;
+  a,
+  button {
+    font-weight: 200;
+  }
 }
 
 .cd-nav__grandchild-item {

--- a/common-design/sass/cd-header/_cd-search.scss
+++ b/common-design/sass/cd-header/_cd-search.scss
@@ -10,7 +10,6 @@
   align-items: center;
   background: transparent;
   border: 0;
-  border-left: 1px solid $cd-border-color;
   color: $cd-blue-text-color;
   display: flex;
   font-size: 24px;

--- a/ocha/css/extras.css
+++ b/ocha/css/extras.css
@@ -171,3 +171,5 @@ label > input[type="radio"], label > input[type="checkbox"] {
   margin: 0;
   width: auto;
   height: auto; }
+
+/*# sourceMappingURL=extras.css.map */

--- a/styleguide/css/styleguide.css
+++ b/styleguide/css/styleguide.css
@@ -1483,3 +1483,5 @@ html.styleguide, html.styleguide body {
   margin: 20px;
   font-family: monospace;
   white-space: pre; }
+
+/*# sourceMappingURL=styleguide.css.map */


### PR DESCRIPTION
Summary:
1. Remove grey border on search toggle
2. Menu items that have a grey background or red underline (ie. hover, focus or active) should have black text
3. Child items should be bold
4. Grandchild items should have font-weight 200

### Testing
Pull changes and generate styleguide
Visual checks for menu on desktop and mobile and search toggle
