### PR TITLE
Cd-30 menu toggle

### DIFF
--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -194,12 +194,7 @@ body {
   height: 60px; }
 
 .cd-site-header__actions {
-  float: right;
-  margin-right: -12px; }
-
-@media (min-width: 768px) {
-  .cd-site-header__actions {
-    margin-right: 0; } }
+  float: right; }
 
 /**
  * Common Design Header Dropdowns generic styles.
@@ -269,6 +264,7 @@ body {
   background: transparent;
   border: 0;
   border-left: 1px solid #E6ECF1;
+  border-right: 1px solid #E6ECF1;
   font-size: 14px;
   font-weight: bold;
   color: #4A4A4A;

--- a/common-design/sass/cd-header/_cd-header.scss
+++ b/common-design/sass/cd-header/_cd-header.scss
@@ -33,13 +33,4 @@
 
 .cd-site-header__actions {
   float: right;
-  margin-right: -$cd-container-padding;
-}
-
-@media (min-width: map-get($cd-breakpoints, tablet)) {
-
-  .cd-site-header__actions {
-    margin-right: 0;
-  }
-
 }

--- a/common-design/sass/cd-header/_cd-nav.scss
+++ b/common-design/sass/cd-header/_cd-nav.scss
@@ -10,6 +10,7 @@
   background: transparent;
   border: 0;
   border-left: 1px solid $cd-border-color;
+  border-right: 1px solid $cd-border-color;
   font-size: map-get($cd-font-sizes, medium);
   font-weight: bold;
   color: $cd-default-text-color;


### PR DESCRIPTION
### Summary

Final tweaks to first round of header style changes

Removes a negative margin on mobile menu toggle, and adds a right border so it right aligns with the user menu above it
Already displaying correctly on tablet, maintains desktop main menu right alignment and border

### Testing:

1. Pull `pr origin 17` (<- new favourite!)
2. `gulp dev:sass`
3. Visually confirm main menu toggle was a right border and is aligned nicely