### PR TITLE
CD-28: search

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -46,3 +46,7 @@
   <script src="{{ '/common-design/js/custom-dropdown.js' | prepend: site.baseurl }}"></script>
   <script src="{{ '/common-design/js/custom-search.js' | prepend: site.baseurl }}"></script>
 {% endif %}
+
+{% if page.options contains 'include_cd_header--inline-search' %}
+  <script src="{{ '/common-design/js/custom-search--inline.js' | prepend: site.baseurl }}"></script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,10 @@
 
   <body class="styleguide">
     <div class="page-wrapper">
+      {% if page.options contains 'include_cd_header--inline-search' %}
+      {% include_relative templates/cd-header--inline-search.html %}
+      {% endif %}
+
       {% if page.options contains 'include_cd_header' %}
         {% include_relative templates/cd-header.html %}
       {% endif %}

--- a/common-design/components.html
+++ b/common-design/components.html
@@ -9,25 +9,50 @@ options:
   <div class="sg-page-header">
     <h1 class="sg-page-header__heading"><a href="./">Common Design</a> / Components</h1>
   </div>
-  <div>
 
-   <div class="row">
+  <div class="row">
     <div class="col-sm-6">
       <h2>Styleguide in pieces</h2>
-      <p>Some components are more suitable in certain contexts, so we have variants. Others are global elements intended to provide consistency.</p>
+      <p>Some components are more suitable in certain contexts, so we have variants. Others are global elements
+        intended to provide consistency.</p>
     </div>
   </div>
 
+  <div class="sg-section__item">
 
+    <div class="row">
+
+    <div class="col-sm-6 description">
+      <div class="sg-section__header">
+        <h2>Inline search</h2>
+      </div>
+      <p>To be included in the header when there are few navigation items.</p>
+      <a class="sg-button" href="demo--inline-search.html" title="Inline search demo">View demo</a>
+    </div>
+
+    <div class="col-sm-6 code">
+
+      {% highlight html %}
+
+      <!-- For our code snippets -->
+
+      This is a nice place to put a codepen embed or something, that can display HTML, CSS, JS in tabs
+      {% endhighlight %}
+
+    </div>
+
+  </div>
+
+  <hr>
 
   <div class="sg-section__item">
-    <div class="sg-section__header">
-      <h2>Soft footer</h2>
-    </div>
 
     <div class="row">
 
       <div class="col-sm-6 description">
+        <div class="sg-section__header">
+          <h2>Soft footer</h2>
+        </div>
         <p>For newsletter sign up or social media. For content that doesn't belong in the footer but almost.</p>
         <a class="sg-button" href="demo--soft-footer.html" title="Soft footer demo">View demo</a>
       </div>
@@ -46,4 +71,7 @@ options:
     </div>
 
   </div>
+
+  <hr>
+
 </div>

--- a/common-design/components/cd-navigation--reduced.html
+++ b/common-design/components/cd-navigation--reduced.html
@@ -1,0 +1,45 @@
+<div class="cd-site-header__nav-holder">
+
+  <button type="button" id="cd-nav-toggle" class="cd-site-header__nav-toggle" data-toggle="dropdown">
+    <span class="cd-site-header__nav-label">Menu</span>
+    <span class="icon-arrow-down" aria-hidden="true"></span>
+      <span class="cd-sr-only">Close menu</span>
+    </span>
+  </button>
+
+  <nav role="navigation" id="cd-nav" class="cd-nav cd-dropdown" aria-labelledby="cd-nav-toggle">
+    <ul>
+      <li class="cd-nav__item">
+        <button type="button" class="expanded cd-sub-nav-toggle" data-toggle="dropdown">
+          Option One
+          <span class="icon-arrow-down" aria-hidden="true"></span>
+        </button>
+        <ul class="cd-nav__child-nav cd-dropdown" aria-labelledby="cd-sub-nav-toggle">
+          <li class="cd-nav__child-item">
+            <button type="button" class="expanded cd-sub-sub-nav-toggle" data-toggle="dropdown">
+              Child option
+              <span class="icon-arrow-down" aria-hidden="true"></span>
+            </button>
+            <ul class="cd-nav__grandchild-nav cd-dropdown"  aria-labelledby="cd-sub-nav-toggle">
+              <li  class="cd-nav__grandchild-item">
+                <a href="#">Grand child option</a>
+              </li>
+              <li class="cd-nav__grandchild-item">
+                <a href="#">Grand child option</a>
+              </li>
+            </ul>
+          </li>
+          <li class="cd-nav__child-item">
+            <a href="#">Child option</a>
+          </li>
+        </ul>
+      </li>
+      <li class="cd-nav__item">
+        <a href="#">Option Two</a>
+      </li>
+      <li class="cd-nav__item">
+        <a href="#">Option Three</a>
+      </li>
+    </ul>
+  </nav>
+</div>

--- a/common-design/components/cd-search--inline.html
+++ b/common-design/components/cd-search--inline.html
@@ -1,9 +1,9 @@
 <div class="cd-search--inline">
-  <form role="search" class="cd-search__form" aria-labelledby="cd-search-btn">
-    <div class="cd-search__form-inner">
+  <form role="search" class="cd-search--inline__form" aria-labelledby="cd-search-btn">
+    <div class="cd-search--inline__form-inner">
       <label for="cd-search" class="cd-sr-only">What are you looking for?</label>
-      <input type="search" placeholder="What are you looking for?" name="cd-search" id="cd-search" class="cd-search__input">
-      <button type="submit" class="cd-search__submit">
+      <input type="search" placeholder="What are you looking for?" name="cd-search" id="cd-search" class="cd-search--inline__input">
+      <button type="submit" class="cd-search--inline__submit">
         <span class="icon-search" aria-hidden="true"></span>
         <span class="cd-sr-only">Search</span>
       </button>

--- a/common-design/components/cd-search--inline.html
+++ b/common-design/components/cd-search--inline.html
@@ -1,0 +1,12 @@
+<div class="cd-search--inline">
+  <form role="search" class="cd-search__form" aria-labelledby="cd-search-btn">
+    <div class="cd-search__form-inner">
+      <label for="cd-search" class="cd-sr-only">What are you looking for?</label>
+      <input type="search" placeholder="What are you looking for?" name="cd-search" id="cd-search" class="cd-search__input">
+      <button type="submit" class="cd-search__submit">
+        <span class="icon-search" aria-hidden="true"></span>
+        <span class="cd-sr-only">Search</span>
+      </button>
+    </div>
+  </form>
+</div>

--- a/common-design/components/cd-search--inline.html
+++ b/common-design/components/cd-search--inline.html
@@ -1,8 +1,12 @@
 <div class="cd-search--inline">
+  <button type="button" class="cd-search--inline_btn" data-toggle="dropdown" id="cd-search-btn">
+    <span class="icon-search" aria-hidden="true"></span>
+    <span class="cd-search_btn-text">Search</span>
+  </button>
   <form role="search" class="cd-search--inline__form" aria-labelledby="cd-search-btn">
     <div class="cd-search--inline__form-inner">
       <label for="cd-search" class="cd-sr-only">What are you looking for?</label>
-      <input type="search" placeholder="What are you looking for?" name="cd-search" id="cd-search" class="cd-search--inline__input">
+      <input type="search" placeholder="What are you looking for?" name="cd-search" id="cd-search" class="cd-search--inline__input" autocomplete="off">
       <button type="submit" class="cd-search--inline__submit">
         <span class="icon-search" aria-hidden="true"></span>
         <span class="cd-sr-only">Search</span>

--- a/common-design/components/cd-search.html
+++ b/common-design/components/cd-search.html
@@ -7,7 +7,7 @@
   <form role="search" class="cd-search__form" aria-labelledby="cd-search-btn">
     <div class="cd-search__form-inner">
       <label for="cd-search" class="cd-sr-only">What are you looking for?</label>
-      <input type="search" placeholder="What are you looking for?" name="cd-search" id="cd-search" class="cd-search__input">
+      <input type="search" placeholder="What are you looking for?" name="cd-search" id="cd-search" class="cd-search__input" autocomplete="off">
       <button type="submit" class="cd-search__submit">
         <span class="icon-search" aria-hidden="true"></span>
         <span class="cd-sr-only">Search</span>

--- a/common-design/components/cd-site-header--inline-search.html
+++ b/common-design/components/cd-site-header--inline-search.html
@@ -1,0 +1,15 @@
+<div class="cd-site-header">
+  <div class="cd-container cd-site-header__inner">
+
+    {% include_relative /components/cd-logo.html %}
+
+    <div class="cd-site-header__actions">
+
+      {% include_relative /components/cd-search--inline.html %}
+
+      {% include_relative /components/cd-navigation--reduced.html %}
+
+    </div>
+
+  </div>
+</div>

--- a/common-design/components/cd-site-header.html
+++ b/common-design/components/cd-site-header.html
@@ -5,7 +5,7 @@
 
     <div class="cd-site-header__actions">
 
-      {% include_relative /components/cd-search--inline.html %}
+      {% include_relative /components/cd-search.html %}
 
       {% include_relative /components/cd-navigation.html %}
 

--- a/common-design/components/cd-site-header.html
+++ b/common-design/components/cd-site-header.html
@@ -5,7 +5,7 @@
 
     <div class="cd-site-header__actions">
 
-      {% include_relative /components/cd-search.html %}
+      {% include_relative /components/cd-search--inline.html %}
 
       {% include_relative /components/cd-navigation.html %}
 

--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -668,81 +668,76 @@ ul.cd-nav__grandchild-nav {
  */
 .cd-search--inline {
   float: left;
-  border-left: 1px solid #E6ECF1;
-  border-right: 1px solid #E6ECF1; }
-  .cd-search--inline .cd-search__form {
+  border-left: 1px solid #E6ECF1; }
+  .cd-search--inline .cd-search--inline__form {
     background: #FFF;
     display: block;
-    left: unset;
-    position: relative;
-    right: unset; }
-  .cd-search--inline .cd-search__form-inner {
-    padding: 0; }
-  .cd-search--inline .cd-search__input {
+    position: relative; }
+  .cd-search--inline .cd-search--inline__form-inner::before {
+    bottom: -3px;
+    content: '';
+    background: transparent;
+    height: 3px;
+    left: -1px;
+    position: absolute;
+    right: -1px;
+    transition: background 0.3s ease;
+    width: calc(100% + 1px); }
+  .cd-search--inline .cd-search--inline__form-inner.js-has-focus::before {
+    background: #EB5C6D; }
+  .cd-search--inline .cd-search--inline__input {
     -webkit-appearance: none;
     background: #FFF;
     border: 0;
     border-radius: 0;
     box-shadow: none;
     color: #4A4A4A;
-    font-size: 16px;
+    font-size: 12px;
     height: 60px;
-    height: calc(60px - 16px);
-    padding: 0 45px 0 25px;
-    width: auto; }
-  .cd-search--inline .cd-search__submit {
+    padding: 0 56px 0 16px; }
+  .cd-search--inline .cd-search--inline__input::-webkit-input-placeholder {
+    color: #808080;
+    font-style: italic; }
+  .cd-search--inline .cd-search--inline__input::-moz-placeholder {
+    color: #808080;
+    font-style: italic; }
+  .cd-search--inline .cd-search--inline__input:-ms-input-placeholder {
+    color: #808080;
+    font-style: italic; }
+  .cd-search--inline .cd-search--inline__input:-moz-placeholder {
+    color: #808080;
+    font-style: italic; }
+  .cd-search--inline .cd-search--inline__submit {
     -webkit-align-items: center;
     align-items: center;
     background: #FFF;
     border: 0;
-    border-left: 1px solid #E6ECF1;
     color: #000;
     display: -webkit-flex;
     display: flex;
     font-size: 16px;
     font-weight: bold;
-    height: calc(60px - 16px);
-    margin: 0;
+    height: 60px;
     padding: 0;
     position: absolute;
-    right: 12px;
-    text-transform: uppercase;
-    top: 0; }
-    .cd-search--inline .cd-search__submit .icon-search {
+    right: 0;
+    top: 0;
+    transition: all 0.3s ease; }
+    .cd-search--inline .cd-search--inline__submit::before {
+      content: '';
+      background: #E6ECF1;
+      width: 2px;
+      height: 24px;
+      position: absolute; }
+    .cd-search--inline .cd-search--inline__submit .icon-search {
       font-size: 24px;
       font-weight: bold;
-      padding: 0 10px; }
-    .cd-search--inline .cd-search__submit.js-has-focus {
-      background-color: #EB5C6D; }
-  @media (min-width: 768px) {
-    .cd-search--inline .cd-search__form-inner {
-      margin: 0 auto;
-      max-width: 1220px;
-      padding: 0 24px;
-      position: relative; }
-    .cd-search--inline .cd-search__input {
-      padding: 0 44px 0 30px; }
-    .cd-search--inline .cd-search__submit {
-      right: 0; } }
-  @media (min-width: 1024px) {
-    .cd-search--inline .cd-search_btn-text {
-      display: block; }
-    .cd-search--inline .cd-search__form-inner {
-      margin: 0 auto;
-      padding: 8px 0;
-      position: relative; }
-    .cd-search--inline .cd-search__input {
-      padding: 0 44px 0 8px; }
-    .cd-search--inline .cd-search_btn .icon-search {
-      font-size: 20px; } }
-  @media (min-width: 1200px) {
-    .cd-search--inline .cd-search__form {
-      left: 0;
-      right: 0; }
-    .cd-search--inline .cd-search__form-inner {
-      padding: 0 40px; }
-    .cd-search--inline .cd-search__submit {
-      right: 0; } }
+      padding: 0 16px;
+      color: #808080; }
+    .cd-search--inline .cd-search--inline__submit.js-has-focus, .cd-search--inline .cd-search--inline__submit:hover, .cd-search--inline .cd-search--inline__submit:focus {
+      background-color: #E6ECF1; }
+      .cd-search--inline .cd-search--inline__submit.js-has-focus .icon-search, .cd-search--inline .cd-search--inline__submit:hover .icon-search, .cd-search--inline .cd-search--inline__submit:focus .icon-search {
+        color: #EB5C6D; }
 
 /**
  * Common Design Sites Menu ('OCHA Services')

--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -720,25 +720,152 @@ ul.cd-nav__grandchild-nav {
  * Common Design Search form in header.
  */
 .cd-search--inline {
-  float: left;
-  border-left: 1px solid #E6ECF1; }
-  .cd-search--inline .cd-search--inline__form {
+  float: left; }
+  .cssgrid.flexbox .cd-search--inline {
+    float: none; }
+
+.cd-search--inline_btn {
+  -webkit-align-items: center;
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: #026CB6;
+  display: -webkit-flex;
+  display: flex;
+  font-size: 24px;
+  height: 60px;
+  padding: 0 20px;
+  transition: background 0.3s ease; }
+  .open .cd-search--inline_btn {
+    color: #EB5C6D;
+    position: relative; }
+    .open .cd-search--inline_btn:before {
+      content: "";
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 0 6px 6px 6px;
+      border-color: transparent transparent #E6ECF1 transparent;
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      margin-left: -6px; }
+  .cd-search--inline_btn:hover, .cd-search--inline_btn:focus {
+    background: #FFF;
+    outline: none;
+    color: #80CBFF; }
+  .cd-search--inline_btn:focus {
+    color: #EB5C6D; }
+
+.cd-search--inline_btn .icon-search {
+  font-size: 24px;
+  font-weight: bold;
+  padding: 0 4px 0 0; }
+
+.cd-search--inline_btn-text {
+  font-size: 12px;
+  font-weight: bold;
+  text-transform: uppercase;
+  display: none; }
+
+.cd-search--inline__form {
+  background: #E6ECF1;
+  display: none;
+  height: 60px;
+  left: 0;
+  position: absolute;
+  right: 0; }
+  .open .cd-search--inline__form {
+    display: block; }
+
+.cd-search--inline__form-inner {
+  padding: 8px 12px; }
+
+.cd-search--inline__input {
+  -webkit-appearance: none;
+  background: #FFF;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  color: #4A4A4A;
+  font-size: 16px;
+  height: 60px;
+  height: calc(60px - 16px);
+  padding: 0 45px 0 25px;
+  width: 100%; }
+
+.cd-search--inline__input::-webkit-input-placeholder {
+  color: #4A4A4A;
+  font-style: italic; }
+
+.cd-search--inline__input::-moz-placeholder {
+  color: #4A4A4A;
+  font-style: italic; }
+
+.cd-search--inline__input:-ms-input-placeholder {
+  color: #4A4A4A;
+  font-style: italic; }
+
+.cd-search--inline__input:-moz-placeholder {
+  color: #4A4A4A;
+  font-style: italic; }
+
+.cd-search--inline__input::-webkit-search-cancel-button {
+  position: relative;
+  right: 10px; }
+
+.cd-search--inline__submit {
+  -webkit-align-items: center;
+  align-items: center;
+  background: #4A4A4A;
+  border: 0;
+  color: #FFF;
+  display: -webkit-flex;
+  display: flex;
+  font-size: 16px;
+  font-weight: bold;
+  height: calc(60px - 16px);
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  right: 12px;
+  text-transform: uppercase;
+  top: 8px; }
+  .cd-search--inline__submit .icon-search {
+    font-size: 24px;
+    font-weight: bold;
+    padding: 0 10px; }
+  .cd-search--inline__submit.js-has-focus {
+    background-color: #EB5C6D; }
+
+@media (min-width: 1024px) {
+  .cd-search--inline_btn {
+    display: none; }
+  .cd-search--inline {
+    float: left;
+    border-left: 1px solid #E6ECF1;
+    -webkit-flex: 1 0 auto;
+    flex: 1 0 auto;
+    margin-left: 0; }
+  .cd-search--inline__form {
     background: #FFF;
     display: block;
     position: relative; }
-  .cd-search--inline .cd-search--inline__form-inner::before {
-    bottom: -3px;
-    content: '';
-    background: transparent;
-    height: 3px;
-    left: -1px;
-    position: absolute;
-    right: -1px;
-    transition: background 0.3s ease;
-    width: calc(100% + 1px); }
-  .cd-search--inline .cd-search--inline__form-inner.js-has-focus::before {
+  .cd-search--inline__form-inner {
+    padding: 0; }
+    .cd-search--inline__form-inner::before {
+      bottom: -3px;
+      content: '';
+      background: transparent;
+      height: 3px;
+      left: -1px;
+      position: absolute;
+      right: -1px;
+      transition: background 0.3s ease;
+      width: calc(100% + 1px); }
+  .cd-search--inline__form-inner.js-has-focus::before {
     background: #EB5C6D; }
-  .cd-search--inline .cd-search--inline__input {
+  .cd-search--inline__input {
     -webkit-appearance: none;
     background: #FFF;
     border: 0;
@@ -747,20 +874,21 @@ ul.cd-nav__grandchild-nav {
     color: #4A4A4A;
     font-size: 12px;
     height: 60px;
-    padding: 0 56px 0 16px; }
-  .cd-search--inline .cd-search--inline__input::-webkit-input-placeholder {
+    padding: 0 56px 0 16px;
+    width: 100%; }
+  .cd-search--inline__input::-webkit-input-placeholder {
     color: #808080;
     font-style: italic; }
-  .cd-search--inline .cd-search--inline__input::-moz-placeholder {
+  .cd-search--inline__input::-moz-placeholder {
     color: #808080;
     font-style: italic; }
-  .cd-search--inline .cd-search--inline__input:-ms-input-placeholder {
+  .cd-search--inline__input:-ms-input-placeholder {
     color: #808080;
     font-style: italic; }
-  .cd-search--inline .cd-search--inline__input:-moz-placeholder {
+  .cd-search--inline__input:-moz-placeholder {
     color: #808080;
     font-style: italic; }
-  .cd-search--inline .cd-search--inline__submit {
+  .cd-search--inline__submit {
     -webkit-align-items: center;
     align-items: center;
     background: #FFF;
@@ -776,21 +904,21 @@ ul.cd-nav__grandchild-nav {
     right: 0;
     top: 0;
     transition: all 0.3s ease; }
-    .cd-search--inline .cd-search--inline__submit::before {
+    .cd-search--inline__submit::before {
       content: '';
       background: #E6ECF1;
       width: 2px;
       height: 24px;
       position: absolute; }
-    .cd-search--inline .cd-search--inline__submit .icon-search {
+    .cd-search--inline__submit .icon-search {
       font-size: 24px;
       font-weight: bold;
       padding: 0 16px;
       color: #808080; }
-    .cd-search--inline .cd-search--inline__submit.js-has-focus, .cd-search--inline .cd-search--inline__submit:hover, .cd-search--inline .cd-search--inline__submit:focus {
+    .cd-search--inline__submit.js-has-focus, .cd-search--inline__submit:hover, .cd-search--inline__submit:focus {
       background-color: #E6ECF1; }
-      .cd-search--inline .cd-search--inline__submit.js-has-focus .icon-search, .cd-search--inline .cd-search--inline__submit:hover .icon-search, .cd-search--inline .cd-search--inline__submit:focus .icon-search {
-        color: #EB5C6D; }
+      .cd-search--inline__submit.js-has-focus .icon-search, .cd-search--inline__submit:hover .icon-search, .cd-search--inline__submit:focus .icon-search {
+        color: #EB5C6D; } }
 
 /**
  * Common Design Sites Menu ('OCHA Services')

--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -846,7 +846,7 @@ ul.cd-nav__grandchild-nav {
     border-left: 1px solid #E6ECF1;
     -webkit-flex: 1 0 auto;
     flex: 1 0 auto;
-    margin-left: 0; }
+    margin-left: 30px; }
   .cd-search--inline__form {
     background: #FFF;
     display: block;

--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -622,6 +622,87 @@ ul.cd-nav__grandchild-nav {
     right: 40px; } }
 
 /**
+ * Common Design Search form in header.
+ */
+.cd-search--inline {
+  float: left;
+  border-left: 1px solid #E6ECF1;
+  border-right: 1px solid #E6ECF1; }
+  .cd-search--inline .cd-search__form {
+    background: #FFF;
+    display: block;
+    left: unset;
+    position: relative;
+    right: unset; }
+  .cd-search--inline .cd-search__form-inner {
+    padding: 0; }
+  .cd-search--inline .cd-search__input {
+    -webkit-appearance: none;
+    background: #FFF;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    color: #4A4A4A;
+    font-size: 16px;
+    height: 60px;
+    height: calc(60px - 16px);
+    padding: 0 45px 0 25px;
+    width: auto; }
+  .cd-search--inline .cd-search__submit {
+    -webkit-align-items: center;
+    align-items: center;
+    background: #FFF;
+    border: 0;
+    border-left: 1px solid #E6ECF1;
+    color: #000;
+    display: -webkit-flex;
+    display: flex;
+    font-size: 16px;
+    font-weight: bold;
+    height: calc(60px - 16px);
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    right: 12px;
+    text-transform: uppercase;
+    top: 0; }
+    .cd-search--inline .cd-search__submit .icon-search {
+      font-size: 24px;
+      font-weight: bold;
+      padding: 0 10px; }
+    .cd-search--inline .cd-search__submit.js-has-focus {
+      background-color: #EB5C6D; }
+  @media (min-width: 768px) {
+    .cd-search--inline .cd-search__form-inner {
+      margin: 0 auto;
+      max-width: 1220px;
+      padding: 0 24px;
+      position: relative; }
+    .cd-search--inline .cd-search__input {
+      padding: 0 44px 0 30px; }
+    .cd-search--inline .cd-search__submit {
+      right: 0; } }
+  @media (min-width: 1024px) {
+    .cd-search--inline .cd-search_btn-text {
+      display: block; }
+    .cd-search--inline .cd-search__form-inner {
+      margin: 0 auto;
+      padding: 8px 0;
+      position: relative; }
+    .cd-search--inline .cd-search__input {
+      padding: 0 44px 0 8px; }
+    .cd-search--inline .cd-search_btn .icon-search {
+      font-size: 20px; } }
+  @media (min-width: 1200px) {
+    .cd-search--inline .cd-search__form {
+      left: 0;
+      right: 0; }
+    .cd-search--inline .cd-search__form-inner {
+      padding: 0 40px; }
+    .cd-search--inline .cd-search__submit {
+      right: 0; } }
+
+/**
  * Common Design Sites Menu ('OCHA Services')
  * Button and dropdown with links to OCHA services.
  */

--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -664,6 +664,87 @@ ul.cd-nav__grandchild-nav {
     right: 40px; } }
 
 /**
+ * Common Design Search form in header.
+ */
+.cd-search--inline {
+  float: left;
+  border-left: 1px solid #E6ECF1;
+  border-right: 1px solid #E6ECF1; }
+  .cd-search--inline .cd-search__form {
+    background: #FFF;
+    display: block;
+    left: unset;
+    position: relative;
+    right: unset; }
+  .cd-search--inline .cd-search__form-inner {
+    padding: 0; }
+  .cd-search--inline .cd-search__input {
+    -webkit-appearance: none;
+    background: #FFF;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    color: #4A4A4A;
+    font-size: 16px;
+    height: 60px;
+    height: calc(60px - 16px);
+    padding: 0 45px 0 25px;
+    width: auto; }
+  .cd-search--inline .cd-search__submit {
+    -webkit-align-items: center;
+    align-items: center;
+    background: #FFF;
+    border: 0;
+    border-left: 1px solid #E6ECF1;
+    color: #000;
+    display: -webkit-flex;
+    display: flex;
+    font-size: 16px;
+    font-weight: bold;
+    height: calc(60px - 16px);
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    right: 12px;
+    text-transform: uppercase;
+    top: 0; }
+    .cd-search--inline .cd-search__submit .icon-search {
+      font-size: 24px;
+      font-weight: bold;
+      padding: 0 10px; }
+    .cd-search--inline .cd-search__submit.js-has-focus {
+      background-color: #EB5C6D; }
+  @media (min-width: 768px) {
+    .cd-search--inline .cd-search__form-inner {
+      margin: 0 auto;
+      max-width: 1220px;
+      padding: 0 24px;
+      position: relative; }
+    .cd-search--inline .cd-search__input {
+      padding: 0 44px 0 30px; }
+    .cd-search--inline .cd-search__submit {
+      right: 0; } }
+  @media (min-width: 1024px) {
+    .cd-search--inline .cd-search_btn-text {
+      display: block; }
+    .cd-search--inline .cd-search__form-inner {
+      margin: 0 auto;
+      padding: 8px 0;
+      position: relative; }
+    .cd-search--inline .cd-search__input {
+      padding: 0 44px 0 8px; }
+    .cd-search--inline .cd-search_btn .icon-search {
+      font-size: 20px; } }
+  @media (min-width: 1200px) {
+    .cd-search--inline .cd-search__form {
+      left: 0;
+      right: 0; }
+    .cd-search--inline .cd-search__form-inner {
+      padding: 0 40px; }
+    .cd-search--inline .cd-search__submit {
+      right: 0; } }
+
+/**
  * Common Design Sites Menu ('OCHA Services')
  * Button and dropdown with links to OCHA services.
  */

--- a/common-design/css/styles.scss
+++ b/common-design/css/styles.scss
@@ -13,6 +13,7 @@
   "../sass/cd-header/cd-logo",
   "../sass/cd-header/cd-nav",
   "../sass/cd-header/cd-search",
+  "../sass/cd-header/cd-search--inline",
   "../sass/cd-header/cd-sites-menu",
   "../sass/cd-header/cd-user-menu",
 

--- a/common-design/demo--inline-search.html
+++ b/common-design/demo--inline-search.html
@@ -1,0 +1,17 @@
+---
+options:
+- hide_header_footer
+- include_cd
+- include_cd_header--inline-search
+- include_cd_footer
+---
+<div class="cd-container">
+
+  <!-- explanatory text, not part of common design layout -->
+  <div style="min-height: 200px; font-family: sans-serif; font-size: 16px; color: #4A4A4A; padding-top: 20px;">
+    <h1 style="font-size: 16px;">Common Design inline search example</h1>
+    <p><a href="index.html">Back to Common Design docs</a></p>
+  </div>
+  <!-- explanatory text ends -->
+
+</div>

--- a/common-design/js/custom-search--inline.js
+++ b/common-design/js/custom-search--inline.js
@@ -1,0 +1,22 @@
+(function($) {
+  $(document).ready(function(){
+
+    // search--inline
+    $('.cd-search--inline .cd-search--inline__input').on('focus', function(e){
+      $(this).parent().find('.cd-search--inline__submit').toggleClass('js-has-focus');
+    });
+
+    $('.cd-search--inline .cd-search--inline__input').on('blur', function(e){
+      $(this).parent().find('.cd-search--inline__submit').toggleClass('js-has-focus');
+    });
+
+    $('.cd-search--inline .cd-search--inline__input').on('focus', function(e){
+      $(this).parent().toggleClass('js-has-focus');
+    });
+
+    $('.cd-search--inline .cd-search--inline__input').on('blur', function(e){
+      $(this).parent().toggleClass('js-has-focus');
+    });
+
+  });
+})(jQuery);

--- a/common-design/js/custom-search.js
+++ b/common-design/js/custom-search.js
@@ -1,11 +1,11 @@
 // @see https://www.drupal.org/docs/7/theming/working-with-javascript-and-jquery
 (function($) {
   $(document).ready(function(){
-    $('.cd-search__input').on('focus', function(e){
+    $('.cd-search .cd-search__input').on('focus', function(e){
       $(this).parent().find('.cd-search__submit').toggleClass('js-has-focus');
     });
 
-    $('.cd-search__input').on('blur', function(e){
+    $('.cd-search .cd-search__input').on('blur', function(e){
       $(this).parent().find('.cd-search__submit').toggleClass('js-has-focus');
     });
   });

--- a/common-design/js/custom-search.js
+++ b/common-design/js/custom-search.js
@@ -3,31 +3,12 @@
   $(document).ready(function(){
 
     // search
-
     $('.cd-search .cd-search__input').on('focus', function(e){
       $(this).parent().find('.cd-search__submit').toggleClass('js-has-focus');
     });
 
     $('.cd-search .cd-search__input').on('blur', function(e){
       $(this).parent().find('.cd-search__submit').toggleClass('js-has-focus');
-    });
-
-    // search--inline
-
-    $('.cd-search--inline .cd-search--inline__input').on('focus', function(e){
-      $(this).parent().find('.cd-search--inline__submit').toggleClass('js-has-focus');
-    });
-
-    $('.cd-search--inline .cd-search--inline__input').on('blur', function(e){
-      $(this).parent().find('.cd-search--inline__submit').toggleClass('js-has-focus');
-    });
-
-    $('.cd-search--inline .cd-search--inline__input').on('focus', function(e){
-      $(this).parent().toggleClass('js-has-focus');
-    });
-
-    $('.cd-search--inline .cd-search--inline__input').on('blur', function(e){
-      $(this).parent().toggleClass('js-has-focus');
     });
 
   });

--- a/common-design/js/custom-search.js
+++ b/common-design/js/custom-search.js
@@ -1,6 +1,9 @@
 // @see https://www.drupal.org/docs/7/theming/working-with-javascript-and-jquery
 (function($) {
   $(document).ready(function(){
+
+    // search
+
     $('.cd-search .cd-search__input').on('focus', function(e){
       $(this).parent().find('.cd-search__submit').toggleClass('js-has-focus');
     });
@@ -8,5 +11,24 @@
     $('.cd-search .cd-search__input').on('blur', function(e){
       $(this).parent().find('.cd-search__submit').toggleClass('js-has-focus');
     });
+
+    // search--inline
+
+    $('.cd-search--inline .cd-search--inline__input').on('focus', function(e){
+      $(this).parent().find('.cd-search--inline__submit').toggleClass('js-has-focus');
+    });
+
+    $('.cd-search--inline .cd-search--inline__input').on('blur', function(e){
+      $(this).parent().find('.cd-search--inline__submit').toggleClass('js-has-focus');
+    });
+
+    $('.cd-search--inline .cd-search--inline__input').on('focus', function(e){
+      $(this).parent().toggleClass('js-has-focus');
+    });
+
+    $('.cd-search--inline .cd-search--inline__input').on('blur', function(e){
+      $(this).parent().toggleClass('js-has-focus');
+    });
+
   });
 })(jQuery);

--- a/common-design/sass/_cd-variables.scss
+++ b/common-design/sass/_cd-variables.scss
@@ -35,6 +35,7 @@ $cd-dark-blue: #025995;
 $cd-bright-blue: #80CBFF;
 $cd-light-blue: #9EC5E2;
 $cd-light-grey: #F2F2F2;
+$cd-mid-grey: #808080;
 $cd-dark-grey: #4A4A4A;
 $cd-dark-bluey-grey: #D3DDE5;
 $cd-mid-bluey-grey: #E6ECF1;

--- a/common-design/sass/cd-header/_cd-search--inline.scss
+++ b/common-design/sass/cd-header/_cd-search--inline.scss
@@ -145,7 +145,7 @@
 
 }
 
-// Start inline search
+// Start inline search for desktop only
 
 @include desktop {
 
@@ -157,7 +157,7 @@
     float: left;
     border-left: 1px solid $cd-border-color;
     flex: 1 0 auto;
-    margin-left: 0;
+    margin-left: 30px;
   }
 
   .cd-search--inline__form {
@@ -256,6 +256,5 @@
         color: $cd-highlight-red;
       }
     }
-
   }
 }

--- a/common-design/sass/cd-header/_cd-search--inline.scss
+++ b/common-design/sass/cd-header/_cd-search--inline.scss
@@ -2,11 +2,163 @@
  * Common Design Search form in header.
  */
 
-
-
 .cd-search--inline {
   float: left;
-  border-left: 1px solid $cd-border-color;
+
+  .cssgrid.flexbox & {
+    float: none;
+  }
+}
+
+.cd-search--inline_btn {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: $cd-blue-text-color;
+  display: flex;
+  font-size: 24px;
+  height: $cd-site-header-height;
+  padding: 0 20px;
+  transition: background 0.3s ease;
+
+  .open & {
+    color: $cd-highlight-red;
+    position: relative;
+
+    &:before {
+      content: "";
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 0 6px 6px 6px;
+      border-color: transparent transparent $cd-border-color transparent;
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      margin-left: -6px;
+    }
+  }
+
+  &:hover,
+  &:focus {
+    background: $cd-white-bg-color;
+    outline: none;
+    color: $cd-bright-blue-text-color;
+  }
+
+  &:focus {
+    color: $cd-highlight-red;
+  }
+}
+
+.cd-search--inline_btn .icon-search {
+  font-size: 24px;
+  font-weight: bold;
+  padding: 0 4px 0 0;
+}
+
+.cd-search--inline_btn-text {
+  font-size: 12px;
+  font-weight: bold;
+  text-transform: uppercase;
+  display: none;
+}
+
+.cd-search--inline__form {
+  background: $cd-mid-bluey-grey;
+  display: none;
+  height: $cd-site-header-height;
+  left: 0;
+  position: absolute;
+  right: 0;
+
+  .open & {
+    display: block;
+  }
+}
+
+.cd-search--inline__form-inner {
+  padding: 8px $cd-container-padding;
+}
+
+.cd-search--inline__input {
+  -webkit-appearance: none;
+  background: $cd-white-bg-color;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  color: $cd-default-text-color;
+  font-size: map-get($cd-font-sizes, large);
+  height: $cd-site-header-height;
+  height: calc(#{$cd-site-header-height} - 16px); //padding
+  padding: 0 45px 0 25px;
+  width: 100%;
+}
+
+.cd-search--inline__input::-webkit-input-placeholder {
+  color: $cd-dark-grey;
+  font-style: italic;
+}
+.cd-search--inline__input::-moz-placeholder {
+  color: $cd-dark-grey;
+  font-style: italic;
+}
+.cd-search--inline__input:-ms-input-placeholder {
+  color: $cd-dark-grey;
+  font-style: italic;
+}
+.cd-search--inline__input:-moz-placeholder {
+  color: $cd-dark-grey;
+  font-style: italic;
+}
+
+.cd-search--inline__input::-webkit-search-cancel-button {
+  position: relative;
+  right: 10px;
+}
+
+.cd-search--inline__submit {
+  align-items: center;
+  background: $cd-dark-grey;
+  border: 0;
+  color: $cd-white-text-color;
+  display: flex;
+  font-size: map-get($cd-font-sizes, large);
+  font-weight: bold;
+  height: calc(#{$cd-site-header-height} - 16px); //padding
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  right: $cd-container-padding;
+  text-transform: uppercase;
+  top: 8px;
+
+  .icon-search {
+    font-size: 24px;
+    font-weight: bold;
+    padding: 0 10px;
+  }
+
+  &.js-has-focus {
+    background-color: $cd-highlight-red;
+  }
+
+}
+
+// Start inline search
+
+@include desktop {
+
+  .cd-search--inline_btn {
+    display: none;
+  }
+
+  .cd-search--inline {
+    float: left;
+    border-left: 1px solid $cd-border-color;
+    flex: 1 0 auto;
+    margin-left: 0;
+  }
 
   .cd-search--inline__form {
     background: $cd-white-bg-color;
@@ -15,6 +167,7 @@
   }
 
   .cd-search--inline__form-inner {
+    padding: 0;
     &::before {
       bottom: -3px;
       content: '';
@@ -44,6 +197,7 @@
     font-size: map-get($cd-font-sizes, default);
     height: $cd-site-header-height;
     padding: 0 56px 0 16px;
+    width: 100%;
   }
 
   .cd-search--inline__input::-webkit-input-placeholder {

--- a/common-design/sass/cd-header/_cd-search--inline.scss
+++ b/common-design/sass/cd-header/_cd-search--inline.scss
@@ -1,0 +1,119 @@
+/**
+ * Common Design Search form in header.
+ */
+
+.cd-search--inline {
+  float: left;
+  border-left: 1px solid $cd-border-color;
+  border-right: 1px solid $cd-border-color;
+
+  .cd-search__form {
+    background: $cd-white-bg-color;
+    display: block;
+    left: unset;
+    position: relative;
+    right: unset;
+  }
+
+  .cd-search__form-inner {
+    padding: 0;
+  }
+
+  .cd-search__input {
+    -webkit-appearance: none;
+    background: $cd-white-bg-color;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    color: $cd-default-text-color;
+    font-size: map-get($cd-font-sizes, large);
+    height: $cd-site-header-height;
+    height: calc(#{$cd-site-header-height} - 16px); //padding
+    padding: 0 45px 0 25px;
+    width: auto;
+  }
+
+  .cd-search__submit {
+    align-items: center;
+    background: $cd-white-bg-color;
+    border: 0;
+    border-left: 1px solid $cd-border-color;
+    color: $cd-dark-text-color;
+    display: flex;
+    font-size: map-get($cd-font-sizes, large);
+    font-weight: bold;
+    height: calc(#{$cd-site-header-height} - 16px); //padding
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    right: $cd-container-padding;
+    text-transform: uppercase;
+    top: 0;
+
+    .icon-search {
+      font-size: 24px;
+      font-weight: bold;
+      padding: 0 10px;
+    }
+
+    &.js-has-focus {
+      background-color: $cd-highlight-red;
+    }
+
+  }
+
+  @media (min-width: map-get($cd-breakpoints, tablet)) {
+
+    .cd-search__form-inner {
+      margin: 0 auto;
+      max-width: $cd-max-width;
+      padding: 0 $cd-container-padding-tablet;
+      position: relative;
+    }
+
+    .cd-search__input {
+      padding: 0 44px 0 30px;
+    }
+
+    .cd-search__submit {
+      right: 0;
+    }
+  }
+
+  @media (min-width: map-get($cd-breakpoints, desktop)) {
+
+    .cd-search_btn-text {
+      display: block;
+    }
+
+    .cd-search__form-inner {
+      margin: 0 auto;
+      padding: 8px 0;
+      position: relative;
+    }
+
+    .cd-search__input {
+      padding: 0 44px 0 8px;
+    }
+
+    .cd-search_btn .icon-search {
+      font-size: 20px;
+    }
+  }
+
+  @media (min-width: map-get($cd-breakpoints, largescreen)) {
+
+    .cd-search__form {
+      left: 0;
+      right: 0;
+    }
+
+    .cd-search__form-inner {
+      padding: 0 $cd-container-padding-largescreen;
+    }
+
+    .cd-search__submit {
+      right: 0;
+    }
+  }
+}

--- a/common-design/sass/cd-header/_cd-search--inline.scss
+++ b/common-design/sass/cd-header/_cd-search--inline.scss
@@ -2,118 +2,106 @@
  * Common Design Search form in header.
  */
 
+
+
 .cd-search--inline {
   float: left;
   border-left: 1px solid $cd-border-color;
-  border-right: 1px solid $cd-border-color;
 
-  .cd-search__form {
+  .cd-search--inline__form {
     background: $cd-white-bg-color;
     display: block;
-    left: unset;
     position: relative;
-    right: unset;
   }
 
-  .cd-search__form-inner {
-    padding: 0;
+  .cd-search--inline__form-inner {
+    &::before {
+      bottom: -3px;
+      content: '';
+      background: transparent;
+      height: 3px;
+      left: -1px;
+      position: absolute;
+      right: -1px;
+      transition: background 0.3s ease;
+      width: calc(100% + 1px);
+    }
   }
 
-  .cd-search__input {
+  .cd-search--inline__form-inner.js-has-focus {
+    &::before {
+      background: $cd-highlight-red;
+    }
+  }
+
+  .cd-search--inline__input {
     -webkit-appearance: none;
     background: $cd-white-bg-color;
     border: 0;
     border-radius: 0;
     box-shadow: none;
     color: $cd-default-text-color;
-    font-size: map-get($cd-font-sizes, large);
+    font-size: map-get($cd-font-sizes, default);
     height: $cd-site-header-height;
-    height: calc(#{$cd-site-header-height} - 16px); //padding
-    padding: 0 45px 0 25px;
-    width: auto;
+    padding: 0 56px 0 16px;
   }
 
-  .cd-search__submit {
+  .cd-search--inline__input::-webkit-input-placeholder {
+    color: $cd-mid-grey;
+    font-style: italic;
+  }
+  .cd-search--inline__input::-moz-placeholder {
+    color: $cd-mid-grey;
+    font-style: italic;
+  }
+  .cd-search--inline__input:-ms-input-placeholder {
+    color: $cd-mid-grey;
+    font-style: italic;
+  }
+  .cd-search--inline__input:-moz-placeholder {
+    color: $cd-mid-grey;
+    font-style: italic;
+  }
+
+  .cd-search--inline__submit {
     align-items: center;
     background: $cd-white-bg-color;
     border: 0;
-    border-left: 1px solid $cd-border-color;
     color: $cd-dark-text-color;
     display: flex;
     font-size: map-get($cd-font-sizes, large);
     font-weight: bold;
-    height: calc(#{$cd-site-header-height} - 16px); //padding
-    margin: 0;
+    height: $cd-site-header-height;
     padding: 0;
     position: absolute;
-    right: $cd-container-padding;
-    text-transform: uppercase;
+    right: 0;
     top: 0;
+    transition: all 0.3s ease;
+
+    &::before {
+      content: '';
+      background: $cd-mid-bluey-grey;
+      width: 2px;
+      height: 24px;
+      position: absolute;
+    }
 
     .icon-search {
       font-size: 24px;
       font-weight: bold;
-      padding: 0 10px;
+      padding: 0 16px;
+      color: $cd-mid-grey;
     }
 
-    &.js-has-focus {
-      background-color: $cd-highlight-red;
+    &.js-has-focus,
+    &:hover,
+    &:focus {
+      background-color: $cd-mid-bluey-grey;
+
+      .icon-search {
+        color: $cd-highlight-red;
+      }
     }
 
-  }
-
-  @media (min-width: map-get($cd-breakpoints, tablet)) {
-
-    .cd-search__form-inner {
-      margin: 0 auto;
-      max-width: $cd-max-width;
-      padding: 0 $cd-container-padding-tablet;
-      position: relative;
-    }
-
-    .cd-search__input {
-      padding: 0 44px 0 30px;
-    }
-
-    .cd-search__submit {
-      right: 0;
-    }
-  }
-
-  @media (min-width: map-get($cd-breakpoints, desktop)) {
-
-    .cd-search_btn-text {
-      display: block;
-    }
-
-    .cd-search__form-inner {
-      margin: 0 auto;
-      padding: 8px 0;
-      position: relative;
-    }
-
-    .cd-search__input {
-      padding: 0 44px 0 8px;
-    }
-
-    .cd-search_btn .icon-search {
-      font-size: 20px;
-    }
-  }
-
-  @media (min-width: map-get($cd-breakpoints, largescreen)) {
-
-    .cd-search__form {
-      left: 0;
-      right: 0;
-    }
-
-    .cd-search__form-inner {
-      padding: 0 $cd-container-padding-largescreen;
-    }
-
-    .cd-search__submit {
-      right: 0;
-    }
   }
 }

--- a/common-design/templates/cd-header--inline-search.html
+++ b/common-design/templates/cd-header--inline-search.html
@@ -1,0 +1,4 @@
+<header class="cd-header" role="banner">
+  {% include_relative /components/cd-global-header.html %}
+  {% include_relative /components/cd-site-header--inline-search.html %}
+</header>


### PR DESCRIPTION
Html, CSS and JS for this variant

Screenshots on how it should appear on [JIRA](https://humanitarian.atlassian.net/browse/CD-28)

We recently concluded that the behaviour should mirror existing inline searches used
https://www.humanitarianresponse.info and https://humanitarian.id/landing
On desktop, the search expands to fill the available space by default
But instead of it remaining visible in the header on tablet and mobile, we agreed we would use the collapsed style of the previous search.

I use class name `search--input` on main wrapper and most children elements to distinguish from the original search, and also copied most of the original search's style to get the same mobile/tablet behaviour

### To test:

1. Checkout this PR
2. Compile styleguide
3. Visit http://localhost:4000/common-design/components.html and click the Inline Search demo link
4. Confirm the inline search works for desktop and works like the original search on tablet and mobile
5. Also note the changes to the styleguide itself (see commits) where I added some conditionals in order to create ademo page for the inline search