### PR TITLE
CD-37: refactor media queries to use shorter syntax

### DIFF
--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -3,7 +3,7 @@
  */
 /**
  * Breakpoints
- * Usage: @media (min-width: map-get($cd-breakpoints, tablet)) {}
+ * Usage: @include tablet {}
  */
 /**
  * Measurements
@@ -22,19 +22,6 @@
 /**
  * Font sizes
  * Usage: font-size: map-get($cd-font-sizes, default);
- */
-/**
- * Mixins used by the Common Design.
- * Can be replaced by equivalents in your theme if appropriate.
- */
-/**
- * Standard clearfix.
- */
-/**
- * Hide content offscreen accessibly.
- */
-/**
- * Un-hide content.
  */
 /**
  * Resets to defaults required for Common Design

--- a/common-design/sass/_cd-mixins.scss
+++ b/common-design/sass/_cd-mixins.scss
@@ -1,11 +1,11 @@
-/**
- * Mixins used by the Common Design.
- * Can be replaced by equivalents in your theme if appropriate.
- */
+//——————————————————————————————————————————————————————————————————————————————
+// Mixins used by the Common Design.
+// Can be replaced by equivalents in your theme if appropriate.
+//——————————————————————————————————————————————————————————————————————————————
 
-/**
- * Standard clearfix.
- */
+//
+// Standard clearfix.
+//
 @mixin clearfix {
   &:after {
     clear: both;
@@ -14,9 +14,9 @@
   }
 }
 
-/**
- * Hide content offscreen accessibly.
- */
+//
+// Hide content offscreen accessibly.
+//
 @mixin hide {
   clip: rect(0,0,0,0);
   height: 1px;
@@ -27,12 +27,58 @@
   width: 1px;
 }
 
-/**
- * Un-hide content.
- */
+//
+// Un-hide content.
+//
 @mixin unhide {
   height: auto;
   margin: 0;
   position: static;
   width: auto;
+}
+
+//——————————————————————————————————————————————————————————————————————————————
+// Breakpoints
+//——————————————————————————————————————————————————————————————————————————————
+@mixin min-width($breakpoint) {
+  @if map-has-key($cd-breakpoints, $breakpoint) {
+    @media (min-width: #{map-get($cd-breakpoints, $breakpoint)}) {
+      @content;
+    }
+  }
+  @else {
+    @warn "Unfortunately, no value could be retrieved from `#{$breakpoint}`. "
+        + "Please make sure it is defined in `$cd-breakpoints` map.";
+  }
+}
+
+@mixin max-width($breakpoint) {
+  @if map-has-key($cd-breakpoints, $breakpoint) {
+    @media (max-width: #{map-get($cd-breakpoints, $breakpoint)}) {
+      @content;
+    }
+  }
+  @else {
+    @warn "Unfortunately, no value could be retrieved from `#{$breakpoint}`. "
+        + "Please make sure it is defined in `$cd-breakpoints` map.";
+  }
+}
+
+
+@mixin tablet {
+  @include min-width('tablet') {
+    @content;
+  }
+}
+
+@mixin desktop {
+  @include min-width('desktop') {
+    @content;
+  }
+}
+
+@mixin xlarge {
+  @include min-width('xlarge') {
+    @content;
+  }
 }

--- a/common-design/sass/_cd-variables.scss
+++ b/common-design/sass/_cd-variables.scss
@@ -4,12 +4,12 @@
 
 /**
  * Breakpoints
- * Usage: @media (min-width: map-get($cd-breakpoints, tablet)) {}
+ * Usage: @include tablet {}
  */
 $cd-breakpoints: (
   tablet: 768px,
   desktop: 1024px,
-  largescreen: 1200px
+  xlarge: 1200px
 );
 
 /**
@@ -20,7 +20,7 @@ $cd-max-width: 1220px;
 $cd-site-padding: 8px;
 $cd-container-padding: 12px;
 $cd-container-padding-tablet: 24px;
-$cd-container-padding-largescreen: 40px;
+$cd-container-padding-xlarge: 40px;
 
 $cd-global-header-height: 35px;
 $cd-site-header-height: 60px;

--- a/common-design/sass/cd-footer/_cd-footer-copyright.scss
+++ b/common-design/sass/cd-footer/_cd-footer-copyright.scss
@@ -30,7 +30,7 @@
   margin: 0 auto;
 }
 
-@media (min-width: map-get($cd-breakpoints, desktop)) {
+@include desktop {
 
   .cd-footer-copyright {
     flex: 0 1 350px;

--- a/common-design/sass/cd-footer/_cd-footer-menu.scss
+++ b/common-design/sass/cd-footer/_cd-footer-menu.scss
@@ -19,7 +19,7 @@
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, tablet)) {
+@include tablet {
   .cd-footer-menu {
     flex: 1 0 100%;
   }
@@ -32,7 +32,7 @@
 
 }
 
-@media (min-width: map-get($cd-breakpoints, desktop)) {
+@include desktop {
 
   .cd-footer-menu {
     text-align: left;

--- a/common-design/sass/cd-footer/_cd-footer-social.scss
+++ b/common-design/sass/cd-footer/_cd-footer-social.scss
@@ -23,14 +23,13 @@ a.cd-footer-social__link {
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, tablet)) {
+@include tablet {
   .cd-footer-social {
     flex: 1 0 100%;
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, desktop)) {
-
+@include desktop {
   .cd-footer-social {
     flex: 0 1 auto;
   }
@@ -42,5 +41,4 @@ a.cd-footer-social__link {
       margin: 0;
     }
   }
-
 }

--- a/common-design/sass/cd-footer/_cd-footer.scss
+++ b/common-design/sass/cd-footer/_cd-footer.scss
@@ -26,8 +26,7 @@
   padding-bottom: 48px;
 }
 
-@media (min-width: map-get($cd-breakpoints, tablet)) {
-
+@include tablet {
   .cd-footer__inner {
     display: flex;
     flex-wrap: wrap;
@@ -39,8 +38,7 @@
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, desktop)) {
-
+@include desktop {
   .cd-footer {
     padding-bottom: 0;
   }

--- a/common-design/sass/cd-footer/_cd-mandate.scss
+++ b/common-design/sass/cd-footer/_cd-mandate.scss
@@ -33,8 +33,7 @@
   margin: 0 auto;
 }
 
-@media (min-width: map-get($cd-breakpoints, desktop)) {
-
+@include desktop {
   .cd-mandate {
     max-width: 780px;
     flex: 1 1 50%;
@@ -56,7 +55,7 @@
   }
 
   .cd-mandate__text {
-    padding-right: $cd-container-padding-largescreen;
+    padding-right: $cd-container-padding-xlarge;
     margin: 0;
     max-width: 100%;
   }

--- a/common-design/sass/cd-footer/_cd-soft-footer.scss
+++ b/common-design/sass/cd-footer/_cd-soft-footer.scss
@@ -36,8 +36,7 @@
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, tablet)) {
-
+@include tablet {
   // override container layout so flexbox justify-content works
   .cd-soft-footer .cd-container:after {
     content: none;
@@ -50,8 +49,7 @@
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, desktop)) {
-
+@include desktop {
   .cd-soft-footer {
     padding: 32px 0;
   }

--- a/common-design/sass/cd-header/_cd-header.scss
+++ b/common-design/sass/cd-header/_cd-header.scss
@@ -36,7 +36,7 @@
     grid-template-rows: $cd-site-header-height;
     grid-column-gap: 1em;
 
-    @media (min-width: map-get($cd-breakpoints, tablet)) {
+    @include tablet {
       grid-template-columns: 186px 1fr;
     }
   }
@@ -59,7 +59,7 @@
     flex-flow: row nowrap;
     justify-content: flex-end;
 
-    @media (min-width: map-get($cd-breakpoints, desktop)) {
+    @include desktop {
       .cd-search {
         flex: 0 0 auto;
       }
@@ -74,7 +74,7 @@
   .cssgrid.flexbox & {
     display: block;
 
-    @media (min-width: map-get($cd-breakpoints, desktop)) {
+    @include desktop {
       display: flex;
       flex-flow: row wrap;
       justify-content: flex-end;
@@ -83,11 +83,11 @@
     > .cd-nav__item {
       flex: 1 0 100%;
 
-      @media (min-width: map-get($cd-breakpoints, desktop)) {
+      @include desktop {
         flex: 1 1 auto;
         max-width: 112px;
       }
-      @media (min-width: map-get($cd-breakpoints, largescreen)) {
+      @include xlarge {
         flex: 1 1 auto;
         max-width: 160px;
       }

--- a/common-design/sass/cd-header/_cd-logo.scss
+++ b/common-design/sass/cd-header/_cd-logo.scss
@@ -24,7 +24,7 @@
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, tablet)) {
+@include tablet {
   .cd-site-logo {
     background: url('../logos/ocha-logo.svg') center no-repeat;
     width: 186px; // width may need to be adjusted depending on logo width.

--- a/common-design/sass/cd-header/_cd-nav.scss
+++ b/common-design/sass/cd-header/_cd-nav.scss
@@ -170,8 +170,7 @@ ul.cd-nav__grandchild-nav {
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, tablet)) {
-
+@include tablet {
   .cd-site-header__nav-toggle {
     border-right: 1px solid $cd-border-color;
 
@@ -181,8 +180,7 @@ ul.cd-nav__grandchild-nav {
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, desktop)) {
-
+@include desktop {
   .cd-site-header__nav-toggle {
     display: none;
   }

--- a/common-design/sass/cd-header/_cd-search.scss
+++ b/common-design/sass/cd-header/_cd-search.scss
@@ -149,8 +149,7 @@
 
 }
 
-@media (min-width: map-get($cd-breakpoints, tablet)) {
-
+@include tablet {
   .cd-search__form-inner {
     margin: 0 auto;
     max-width: $cd-max-width;
@@ -167,8 +166,7 @@
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, desktop)) {
-
+@include desktop {
   .cd-search_btn-text {
     display: block;
   }
@@ -178,18 +176,17 @@
   }
 }
 
-@media (min-width: map-get($cd-breakpoints, largescreen)) {
-
+@include xlarge {
   .cd-search__form {
     left: 8px;
     right: 8px;
   }
 
   .cd-search__form-inner {
-    padding: 8px $cd-container-padding-largescreen;
+    padding: 8px $cd-container-padding-xlarge;
   }
 
   .cd-search__submit {
-    right: $cd-container-padding-largescreen;
+    right: $cd-container-padding-xlarge;
   }
 }

--- a/common-design/sass/cd-header/_cd-sites-menu.scss
+++ b/common-design/sass/cd-header/_cd-sites-menu.scss
@@ -148,8 +148,7 @@
   background-position: 0 -144px;
 }
 
-@media (min-width: map-get($cd-breakpoints, tablet)) {
-
+@include tablet {
   .cd-sites-btn {
     display: flex;
     width: auto;
@@ -208,12 +207,10 @@
 
 }
 
-@media (min-width: map-get($cd-breakpoints, largescreen)) {
-
+@include xlarge {
   .cd-sites-dropdown__inner {
     -ms-grid-columns: 1fr 120px 1fr 120px 1fr;
     grid-gap: 120px;
-    padding: 0 $cd-container-padding-largescreen;
+    padding: 0 $cd-container-padding-xlarge;
   }
-
 }

--- a/common-design/sass/cd-header/_cd-user-menu.scss
+++ b/common-design/sass/cd-header/_cd-user-menu.scss
@@ -167,7 +167,7 @@ button.cd-user-menu__item {
   border-bottom: 1px solid transparent;
 }
 
-@media (min-width: map-get($cd-breakpoints, tablet)) {
+@include tablet {
 
   .cd-user-menu__item {
     max-width: none;

--- a/common-design/sass/cd-layout/_cd-layout.scss
+++ b/common-design/sass/cd-layout/_cd-layout.scss
@@ -30,26 +30,20 @@ body {
   max-width: $cd-max-width;
 }
 
-@media (min-width: map-get($cd-breakpoints, tablet)) {
-
+@include tablet {
   .cd-container {
     padding: 0 $cd-container-padding-tablet;
   }
-
 }
 
-@media (min-width: map-get($cd-breakpoints, desktop)) {
-
+@include desktop {
   html {
     padding: 0 $cd-site-padding;
   }
-
 }
 
-@media (min-width: map-get($cd-breakpoints, largescreen)) {
-
+@include xlarge {
   .cd-container {
-    padding: 0 $cd-container-padding-largescreen;
+    padding: 0 $cd-container-padding-xlarge;
   }
-
 }


### PR DESCRIPTION
PR adds the following `@mixin` convenience functions for managing CSS Media Queries:

* `min-width('breakpoint')`
* `max-width('breakpoint')`
* `tablet` => `min-width('tablet')`
* `desktop` => `min-width('desktop')`
* `xlarge` => `min-width('xlarge')` (formerly `largescreen`)

Additionally, when an unrecognized breakpoint is supplied as an argument, you get a warning:
```
WARNING: Unfortunately, no value could be retrieved from `xxxl`. Please make sure it is defined in `$cd-breakpoints` map.
         on line 50 of common-design/sass/_cd-mixins.scss, in mixin `min-width`
         from line 45 of common-design/sass/cd-layout/_cd-layout.scss
         from line 25 of common-design/css/styles.scss
```

The easiest way to confirm nothing broke is actually in the diff itself. There is no (meaningful) change to the compiled CSS. 💯 