### PR TITLE
adjust the link in logo so it work on live demo

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,7 @@
   </div>
   <div class="cd-site-header">
     <div class="cd-container cd-site-header__inner">
-      <a href="/index.html" class="cd-site-logo">
+      <a href="/styleguide/index.html" class="cd-site-logo">
         <span class="cd-sr-only">OCHA</span>
       </a>
     </div>


### PR DESCRIPTION
The live styleguide redirects to /styleguide so I've set the logo to link to /styleguide/index.html so it works on the live demo. It won't work locally as locally the index.html is being served from the root.