### PR TITLE
Follow-up to #31

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,7 @@
   </div>
   <div class="cd-site-header">
     <div class="cd-container cd-site-header__inner">
-      <a href="/styleguide/index.html" class="cd-site-logo">
+      <a href="{{ site.baseurl }}/index.html" class="cd-site-logo">
         <span class="cd-sr-only">OCHA</span>
       </a>
     </div>


### PR DESCRIPTION
The `/styleguide` path prevents us from following links in local dev. `site.baseurl` will point to the right place in both environments.