### PR TITLE
Inline search IE 11 fix

### DIFF
--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -789,7 +789,6 @@ ul.cd-nav__grandchild-nav {
   box-shadow: none;
   color: #4A4A4A;
   font-size: 16px;
-  height: 60px;
   height: calc(60px - 16px);
   padding: 0 45px 0 25px;
   width: 100%; }
@@ -874,8 +873,12 @@ ul.cd-nav__grandchild-nav {
     color: #4A4A4A;
     font-size: 12px;
     height: 60px;
-    padding: 0 56px 0 16px;
-    width: 100%; }
+    padding: 0 72px 0 16px;
+    width: 100%;
+    min-width: 230px; }
+  .cd-search--inline__input::-webkit-search-cancel-button {
+    position: relative;
+    right: -10px; }
   .cd-search--inline__input::-webkit-input-placeholder {
     color: #808080;
     font-style: italic; }
@@ -889,13 +892,10 @@ ul.cd-nav__grandchild-nav {
     color: #808080;
     font-style: italic; }
   .cd-search--inline__submit {
-    -webkit-align-items: center;
-    align-items: center;
     background: #FFF;
     border: 0;
+    border-left: 1px solid #E6ECF1;
     color: #000;
-    display: -webkit-flex;
-    display: flex;
     font-size: 16px;
     font-weight: bold;
     height: 60px;
@@ -904,12 +904,6 @@ ul.cd-nav__grandchild-nav {
     right: 0;
     top: 0;
     transition: all 0.3s ease; }
-    .cd-search--inline__submit::before {
-      content: '';
-      background: #E6ECF1;
-      width: 2px;
-      height: 24px;
-      position: absolute; }
     .cd-search--inline__submit .icon-search {
       font-size: 24px;
       font-weight: bold;
@@ -918,7 +912,26 @@ ul.cd-nav__grandchild-nav {
     .cd-search--inline__submit.js-has-focus, .cd-search--inline__submit:hover, .cd-search--inline__submit:focus {
       background-color: #E6ECF1; }
       .cd-search--inline__submit.js-has-focus .icon-search, .cd-search--inline__submit:hover .icon-search, .cd-search--inline__submit:focus .icon-search {
-        color: #EB5C6D; } }
+        color: #EB5C6D; }
+  .cssgrid.flexbox .cd-search--inline__submit {
+    -webkit-align-items: center;
+    align-items: center;
+    border: 0;
+    display: -webkit-flex;
+    display: flex; }
+    .cssgrid.flexbox .cd-search--inline__submit::before {
+      content: '';
+      background: #E6ECF1;
+      width: 2px;
+      height: 24px;
+      position: absolute; } }
+
+@media all and (min-width: 1024px) and (-ms-high-contrast: none) {
+  input[type=search]::-ms-clear,
+  input[type=search]::-ms-reveal {
+    display: none;
+    width: 0;
+    height: 0; } }
 
 /**
  * Common Design Sites Menu ('OCHA Services')

--- a/common-design/sass/cd-header/_cd-search--inline.scss
+++ b/common-design/sass/cd-header/_cd-search--inline.scss
@@ -89,8 +89,7 @@
   box-shadow: none;
   color: $cd-default-text-color;
   font-size: map-get($cd-font-sizes, large);
-  height: $cd-site-header-height;
-  height: calc(#{$cd-site-header-height} - 16px); //padding
+  height: calc(#{$cd-site-header-height} - 16px); //padding.
   padding: 0 45px 0 25px;
   width: 100%;
 }
@@ -125,7 +124,7 @@
   display: flex;
   font-size: map-get($cd-font-sizes, large);
   font-weight: bold;
-  height: calc(#{$cd-site-header-height} - 16px); //padding
+  height: calc(#{$cd-site-header-height} - 16px); //padding.
   margin: 0;
   padding: 0;
   position: absolute;
@@ -145,8 +144,7 @@
 
 }
 
-// Start inline search for desktop only
-
+// Start inline search for desktop only.
 @include desktop {
 
   .cd-search--inline_btn {
@@ -196,8 +194,14 @@
     color: $cd-default-text-color;
     font-size: map-get($cd-font-sizes, default);
     height: $cd-site-header-height;
-    padding: 0 56px 0 16px;
+    padding: 0 72px 0 16px;
     width: 100%;
+    min-width: 230px;
+  }
+
+  .cd-search--inline__input::-webkit-search-cancel-button {
+    position: relative;
+    right: -10px;
   }
 
   .cd-search--inline__input::-webkit-input-placeholder {
@@ -218,11 +222,10 @@
   }
 
   .cd-search--inline__submit {
-    align-items: center;
     background: $cd-white-bg-color;
     border: 0;
+    border-left: 1px solid $cd-mid-bluey-grey;
     color: $cd-dark-text-color;
-    display: flex;
     font-size: map-get($cd-font-sizes, large);
     font-weight: bold;
     height: $cd-site-header-height;
@@ -231,14 +234,6 @@
     right: 0;
     top: 0;
     transition: all 0.3s ease;
-
-    &::before {
-      content: '';
-      background: $cd-mid-bluey-grey;
-      width: 2px;
-      height: 24px;
-      position: absolute;
-    }
 
     .icon-search {
       font-size: 24px;
@@ -257,4 +252,33 @@
       }
     }
   }
+
+  // Submit button treatment for modern browsers.
+  .cssgrid.flexbox {
+
+    .cd-search--inline__submit {
+      align-items: center;
+      border: 0;
+      display: flex;
+
+      &::before {
+        content: '';
+        background: $cd-mid-bluey-grey;
+        width: 2px;
+        height: 24px;
+        position: absolute;
+      }
+    }
+  }
+
+  // Removes search cancel x on IE 11 only.
+  @media all and (-ms-high-contrast:none) {
+    input[type=search]::-ms-clear,
+    input[type=search]::-ms-reveal {
+      display: none;
+      width: 0;
+      height: 0;
+    }
+  }
 }
+


### PR DESCRIPTION
Increase padding on input so placeholder text is not cut off in IE 11
mentioned in https://github.com/UN-OCHA/styleguide/pull/18#pullrequestreview-143962535

Adjust submit button style default rule for better behaviour in ie11
Result: note the full-height left border
![ie-11-search](https://user-images.githubusercontent.com/1835923/43885727-f48037e6-9bb9-11e8-8262-927edbc7bcbc.png)

Override it with modernizr classes to add a :before pseudo element for modern browsers, to achieve the half-height left border seen here: https://un-ocha.github.io/styleguide/common-design/demo--inline-search.html

Remove search-cancel from ie11 desktop only, due to its size being hard to control and there not being enough room in the input to accommodate

IE 11 before:
![ie-11-search-cancel](https://user-images.githubusercontent.com/1835923/43885813-3e73d376-9bba-11e8-932d-edf2ff1a948d.png)

When IE has flexbox support OR when the input spans 100% and there is enough space in the input for the big X, I left that as is.

IE 11 current:
![ie11-search-cancel-mobile](https://user-images.githubusercontent.com/1835923/43885880-72f64930-9bba-11e8-91fa-87ffe94340cd.png)

IE 17 current:
![ie-17-search-cancel](https://user-images.githubusercontent.com/1835923/43885840-50bb9294-9bba-11e8-926d-c25d855b6bca.png)