### PR TITLE
CD-54 refine search

### DIFF
--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -600,6 +600,8 @@ ul.cd-nav__grandchild-nav {
       bottom: 0;
       left: 50%;
       margin-left: -6px; }
+    .open .cd-search_btn:hover, .open .cd-search_btn:focus {
+      color: #EB5C6D; }
   .cd-search_btn:hover, .cd-search_btn:focus {
     background: #FFF;
     outline: none;
@@ -641,7 +643,6 @@ ul.cd-nav__grandchild-nav {
   box-shadow: none;
   color: #4A4A4A;
   font-size: 16px;
-  height: 60px;
   height: calc(60px - 16px);
   padding: 0 45px 0 25px;
   width: 100%; }
@@ -750,6 +751,8 @@ ul.cd-nav__grandchild-nav {
       bottom: 0;
       left: 50%;
       margin-left: -6px; }
+    .open .cd-search--inline_btn:hover, .open .cd-search--inline_btn:focus {
+      color: #EB5C6D; }
   .cd-search--inline_btn:hover, .cd-search--inline_btn:focus {
     background: #FFF;
     outline: none;
@@ -843,8 +846,8 @@ ul.cd-nav__grandchild-nav {
   .cd-search--inline {
     float: left;
     border-left: 1px solid #E6ECF1;
-    -webkit-flex: 1 0 auto;
-    flex: 1 0 auto;
+    -webkit-flex: 0 1 400px;
+    flex: 0 1 400px;
     margin-left: 30px; }
   .cd-search--inline__form {
     background: #FFF;

--- a/common-design/js/custom-search--inline.js
+++ b/common-design/js/custom-search--inline.js
@@ -1,21 +1,30 @@
 (function($) {
   $(document).ready(function(){
 
-    // search--inline
+    // Apply focus to input when dropdown is shown.
+    $('.cd-search--inline').on('shown.bs.dropdown', function () {
+      $(this).find('#cd-search').focus();
+    });
+
+    $('.cd-search--inline').on('hidden.bs.dropdown', function () {
+      $(this).find('#cd-search').blur();
+    });
+
+    // Add class on submit button when input has focus.
+    $('.cd-search--inline .cd-search--inline__input').on('focus', function(e) {
+      $(this).parent().find('.cd-search--inline__submit').addClass('js-has-focus');
+    });
+
+    $('.cd-search--inline .cd-search--inline__input').on('blur', function(e) {
+      $(this).parent().find('.cd-search--inline__submit').removeClass('js-has-focus');
+    });
+
     $('.cd-search--inline .cd-search--inline__input').on('focus', function(e){
-      $(this).parent().find('.cd-search--inline__submit').toggleClass('js-has-focus');
+      $(this).parent().addClass('js-has-focus');
     });
 
     $('.cd-search--inline .cd-search--inline__input').on('blur', function(e){
-      $(this).parent().find('.cd-search--inline__submit').toggleClass('js-has-focus');
-    });
-
-    $('.cd-search--inline .cd-search--inline__input').on('focus', function(e){
-      $(this).parent().toggleClass('js-has-focus');
-    });
-
-    $('.cd-search--inline .cd-search--inline__input').on('blur', function(e){
-      $(this).parent().toggleClass('js-has-focus');
+      $(this).parent().removeClass('js-has-focus');
     });
 
   });

--- a/common-design/js/custom-search.js
+++ b/common-design/js/custom-search.js
@@ -2,13 +2,22 @@
 (function($) {
   $(document).ready(function(){
 
-    // search
-    $('.cd-search .cd-search__input').on('focus', function(e){
-      $(this).parent().find('.cd-search__submit').toggleClass('js-has-focus');
+    // Apply focus to input when dropdown is shown.
+    $('.cd-search').on('shown.bs.dropdown', function () {
+      $(this).find('#cd-search').focus();
     });
 
-    $('.cd-search .cd-search__input').on('blur', function(e){
-      $(this).parent().find('.cd-search__submit').toggleClass('js-has-focus');
+    $('.cd-search').on('hidden.bs.dropdown', function () {
+      $(this).find('#cd-search').blur();
+    });
+
+    // Add class on submit button when input has focus.
+    $('.cd-search .cd-search__input').on('focus', function(e) {
+      $(this).parent().find('.cd-search__submit').addClass('js-has-focus');
+    });
+
+    $('.cd-search .cd-search__input').on('blur', function(e) {
+      $(this).parent().find('.cd-search__submit').removeClass('js-has-focus');
     });
 
   });

--- a/common-design/sass/cd-header/_cd-search--inline.scss
+++ b/common-design/sass/cd-header/_cd-search--inline.scss
@@ -37,6 +37,11 @@
       left: 50%;
       margin-left: -6px;
     }
+
+    &:hover,
+    &:focus {
+      color: $cd-highlight-red;
+    }
   }
 
   &:hover,
@@ -154,7 +159,7 @@
   .cd-search--inline {
     float: left;
     border-left: 1px solid $cd-border-color;
-    flex: 1 0 auto;
+    flex: 0 1 400px;
     margin-left: 30px;
   }
 

--- a/common-design/sass/cd-header/_cd-search.scss
+++ b/common-design/sass/cd-header/_cd-search.scss
@@ -37,6 +37,11 @@
       left: 50%;
       margin-left: -6px;
     }
+
+    &:hover,
+    &:focus {
+      color: $cd-highlight-red;
+    }
   }
 
   &:hover,
@@ -93,8 +98,7 @@
   box-shadow: none;
   color: $cd-default-text-color;
   font-size: map-get($cd-font-sizes, large);
-  height: $cd-site-header-height;
-  height: calc(#{$cd-site-header-height} - 16px); //padding
+  height: calc(#{$cd-site-header-height} - 16px); //padding.
   padding: 0 45px 0 25px;
   width: 100%;
 }
@@ -129,7 +133,7 @@
   display: flex;
   font-size: map-get($cd-font-sizes, large);
   font-weight: bold;
-  height: calc(#{$cd-site-header-height} - 16px); //padding
+  height: calc(#{$cd-site-header-height} - 16px); //padding.
   margin: 0;
   padding: 0;
   position: absolute;


### PR DESCRIPTION
Inline search has max-width set so it no longer takes all available space.

It aligns right against menu
![inline-search-max-width](https://user-images.githubusercontent.com/1835923/43954452-e020fb94-9c9c-11e8-82c1-cb7b45b13225.png)

Based on @rupl feedback https://github.com/UN-OCHA/styleguide/pull/9#discussion_r203362872 
the search input gains focus and blur when the search button to expose the form is toggled
![search-focus-on-click](https://user-images.githubusercontent.com/1835923/43954524-1f24d0e0-9c9d-11e8-99bb-d4cc7631ddef.png)
Also applied this to the search--inline which has same behaviour on < tablet.

Well cross-browser tested but I should have kept a specific list :)
