### PR TITLE
CD-54 inline search input font size

### DIFF
--- a/common-design/css/styles.css
+++ b/common-design/css/styles.css
@@ -874,7 +874,7 @@ ul.cd-nav__grandchild-nav {
     border-radius: 0;
     box-shadow: none;
     color: #4A4A4A;
-    font-size: 12px;
+    font-size: 14px;
     height: 60px;
     padding: 0 72px 0 16px;
     width: 100%;

--- a/common-design/sass/cd-header/_cd-search--inline.scss
+++ b/common-design/sass/cd-header/_cd-search--inline.scss
@@ -197,7 +197,7 @@
     border-radius: 0;
     box-shadow: none;
     color: $cd-default-text-color;
-    font-size: map-get($cd-font-sizes, default);
+    font-size: map-get($cd-font-sizes, medium);
     height: $cd-site-header-height;
     padding: 0 72px 0 16px;
     width: 100%;


### PR DESCRIPTION
increase font-size of inline search input to 14 on desktop. Should remain 16px in all other cases